### PR TITLE
Bumpversion fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,8 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 tag = True
 
 [bumpversion:file:setup.py]
+
 [bumpversion:file:wordscapesolver/__init__.py]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 config = {
-    "version": "0.3.0",
+    "version": "0.4.0",
     "name": "wordscapesolver",
     "description": "<MODULE_DESCRIPTION>",
     "url": "",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 config = {
-    "version": "0.0.1",
+    "version": "0.3.0",
     "name": "wordscapesolver",
     "description": "<MODULE_DESCRIPTION>",
     "url": "",

--- a/wordscapesolver/__init__.py
+++ b/wordscapesolver/__init__.py
@@ -1,2 +1,2 @@
 """wordscapesolver package"""
-__version__ = "0.0.1"
+__version__ = "0.3.0"

--- a/wordscapesolver/__init__.py
+++ b/wordscapesolver/__init__.py
@@ -1,2 +1,2 @@
 """wordscapesolver package"""
-__version__ = "0.3.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
Fixed use of bumpversion by manually resetting version entries to v.0.3.0 then running bumpversion minor to update to next minor release